### PR TITLE
Fix prop type validation error if no 'to' specified on portal

### DIFF
--- a/src/components/portal.vue
+++ b/src/components/portal.vue
@@ -88,8 +88,8 @@
             ...Target,
             parent: this,
             propsData: {
-              name: this.to || Math.round(Math.random() * 10000000),
-              tag: el.tagName,
+              name: this.to || String(Math.round(Math.random() * 10000000)),
+              tag: el.tagName
               attributes,
             },
           })


### PR DESCRIPTION
Currently if I leave off the `to` prop on a `Portal` targeting an element outside the VueApp the `PortalTarget` throws a prop type validation error due to a `Number` being passed in.