### PR TITLE
Feature/multiple portals in one target

### DIFF
--- a/example/components/multiple/destination.vue
+++ b/example/components/multiple/destination.vue
@@ -1,0 +1,25 @@
+<template>
+    <container type="destination">
+        <h2>List<span v-if="showMultiple">s</span></h2>
+        <button type="button" @click="toggleMultiple">Toggle Multiple</button>
+        <portal-target name="lists" :multiple="showMultiple">
+
+        </portal-target>
+    </container>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                showMultiple: true,
+            }
+        },
+
+        methods: {
+            toggleMultiple() {
+                this.showMultiple = !this.showMultiple;
+            }
+        }
+    }
+</script>

--- a/example/components/multiple/multiple.vue
+++ b/example/components/multiple/multiple.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="wrapper">
-        <src name="Grocery List"></src>
-        <src name="Santa"></src>
-        <src name="Menu"></src>
+      <src v-for="list in lists" :list="list" :key="list.id"></src>
         <destination></destination>
     </div>
 </template>
@@ -11,7 +9,44 @@
     import Src from "./source.vue";
     import Destination from './destination.vue';
 
+    const startingItems = [
+      'carrots',
+      'detergent',
+      'lego',
+      'mushrooms',
+      'pudding',
+      'risotto',
+      'spaghetti',
+      'super nintendo',
+      'teddy bear',
+      'train set',
+      'yoghurt',
+    ];
+
+    function pickStartItems(count) {
+      const items = []
+      for (let i = 0; i < count; i++) {
+        items.push(startingItems[Math.floor(Math.random() * startingItems.length)])
+      }
+      return items
+    }
+
     export default {
         components: {Src, Destination},
+      data() {
+          const lists = [];
+          const names = ['Grocery List', 'Christmas Presents', 'Menu'];
+          for (const id in names) {
+            lists.push({
+              id,
+              name: names[id],
+              enabled: true,
+              items: pickStartItems(parseInt(id) + 2),
+            })
+          }
+          return {
+            lists
+          }
+      }
     }
 </script>

--- a/example/components/multiple/multiple.vue
+++ b/example/components/multiple/multiple.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="wrapper">
+        <src name="Grocery List"></src>
+        <src name="Santa"></src>
+        <src name="Menu"></src>
+        <destination></destination>
+    </div>
+</template>
+
+<script>
+    import Src from "./source.vue";
+    import Destination from './destination.vue';
+
+    export default {
+        components: {Src, Destination},
+    }
+</script>

--- a/example/components/multiple/source.vue
+++ b/example/components/multiple/source.vue
@@ -11,7 +11,7 @@
 
     <button @click="togglePortal">Toggle Portal</button>
 
-    <portal to="lists" :disabled="!list.enabled">
+    <portal to="lists" :disabled="!list.enabled" :order="parseInt(list.id)">
       <h3>{{ list.name }}</h3>
       <ul>
         <li v-for="(item, i) in items" :key="i">{{ item }}</li>

--- a/example/components/multiple/source.vue
+++ b/example/components/multiple/source.vue
@@ -1,58 +1,50 @@
 <template>
-    <container type="source">
-        <h2>{{ name }}</h2>
-        <form @submit.prevent.stop="addItem">
-            <input type="text" v-model="newItem">
-            <button>Add</button>
-        </form>
-        <pre>{{ $data }}</pre>
-        <portal to="lists">
-            <h3>{{ name }}</h3>
-            <ul>
-                <li v-for="(item, i) in items" :key="i">{{ item }}</li>
-            </ul>
-        </portal>
-    </container>
+  <container type="source">
+    <h2>{{ list.name }}</h2>
+
+    <form @submit.prevent.stop="addItem">
+      <input type="text" v-model="newItem">
+      <button>Add</button>
+    </form>
+
+    <pre>{{ list.items }}</pre>
+
+    <button @click="togglePortal">Toggle Portal</button>
+
+    <portal to="lists" :disabled="!list.enabled">
+      <h3>{{ list.name }}</h3>
+      <ul>
+        <li v-for="(item, i) in items" :key="i">{{ item }}</li>
+      </ul>
+    </portal>
+  </container>
 </template>
 
 <script>
-    const startingItems = [
-        'carrots',
-        'detergent',
-        'lego',
-        'mushrooms',
-        'pudding',
-        'risotto',
-        'spaghetti',
-        'super nintendo',
-        'teddy bear',
-        'train set',
-        'yoghurt',
-    ];
+  export default {
+    props: ['list'],
 
-    function pickStartItems(count) {
-        const items = []
-        for (let i = 0; i < count; i++) {
-            items.push(startingItems[Math.floor(Math.random() * startingItems.length)])
-        }
-        return items
+    data () {
+      return {
+        newItem: '',
+      }
+    },
+
+    methods: {
+      addItem () {
+        this.items.push(this.newItem)
+        this.newItem = ''
+      },
+
+      togglePortal () {
+        this.list.enabled = !this.list.enabled;
+      }
+    },
+
+    computed: {
+      items () {
+        return this.list.items;
+      }
     }
-
-    export default {
-        props: ['name'],
-
-        data() {
-            return {
-                newItem: '',
-                items: pickStartItems(3),
-            }
-        },
-
-        methods: {
-            addItem() {
-                this.items.push(this.newItem)
-                this.newItem = ''
-            }
-        }
-    }
+  }
 </script>

--- a/example/components/multiple/source.vue
+++ b/example/components/multiple/source.vue
@@ -1,0 +1,58 @@
+<template>
+    <container type="source">
+        <h2>{{ name }}</h2>
+        <form @submit.prevent.stop="addItem">
+            <input type="text" v-model="newItem">
+            <button>Add</button>
+        </form>
+        <pre>{{ $data }}</pre>
+        <portal to="lists">
+            <h3>{{ name }}</h3>
+            <ul>
+                <li v-for="(item, i) in items" :key="i">{{ item }}</li>
+            </ul>
+        </portal>
+    </container>
+</template>
+
+<script>
+    const startingItems = [
+        'carrots',
+        'detergent',
+        'lego',
+        'mushrooms',
+        'pudding',
+        'risotto',
+        'spaghetti',
+        'super nintendo',
+        'teddy bear',
+        'train set',
+        'yoghurt',
+    ];
+
+    function pickStartItems(count) {
+        const items = []
+        for (let i = 0; i < count; i++) {
+            items.push(startingItems[Math.floor(Math.random() * startingItems.length)])
+        }
+        return items
+    }
+
+    export default {
+        props: ['name'],
+
+        data() {
+            return {
+                newItem: '',
+                items: pickStartItems(3),
+            }
+        },
+
+        methods: {
+            addItem() {
+                this.items.push(this.newItem)
+                this.newItem = ''
+            }
+        }
+    }
+</script>

--- a/example/router.js
+++ b/example/router.js
@@ -11,6 +11,7 @@ import MountToExternal from './components/mount-to/mount-to-external.vue'
 import EmptyPortal from './components/empty-portal/index.vue'
 import DefaultSlotContent from './components/default-content-on-target/index.vue'
 import Transitions from './components/transitions/transitions.vue'
+import Multiple from './components/multiple/multiple.vue'
 
 Vue.use(VueRouter)
 
@@ -58,6 +59,10 @@ const routes = [
   {
     path: '/Mount-to-external-element',
     component: MountToExternal,
+  },
+  {
+    path: '/multiple',
+    component: Multiple,
   },
 ]
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "repository": "git@github.com:LinusBorg/portal-vue.git",
   "scripts": {
     "lint": "eslint src/",
+    "lint:test": "eslint test/",
     "build": "npm run lint && cross-env NODE_ENV=production rollup -c build/rollup.conf.prod.js && uglifyjs dist/portal-vue.js -c -m > dist/portal-vue.min.js",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --watch --config build/webpack.conf.js --inline --hot",
     "prod": "NODE_ENV=production webpack-dev-server --watch --config build/webpack.conf.js --inline --hot",

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -1,18 +1,18 @@
 // import { transports } from './wormhole'
-import {combinePassengers} from '../utils'
+import { combinePassengers } from '../utils'
 import wormhole from './wormhole'
 
 export default {
   abstract: true,
   name: 'portalTarget',
   props: {
-    attributes: {type: Object},
-    multiple: {type: Boolean, default: false},
-    name: {type: String, required: true},
-    slim: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-    transition: {type: [Boolean, String, Object], default: false},
-    transitionEvents: {type: Object, default: () => ({})},
+    attributes: { type: Object },
+    multiple: { type: Boolean, default: false },
+    name: { type: String, required: true },
+    slim: { type: Boolean, default: false },
+    tag: { type: String, default: 'div' },
+    transition: { type: [Boolean, String, Object], default: false },
+    transitionEvents: { type: Object, default: () => ({}) },
   },
   data () {
     return {
@@ -111,12 +111,12 @@ export default {
       // We have to do this to emulate the normal behaviour of transitions without `appear`
       // because in Portals, transitions can behave as if appear was defined under certain conditions.
       if (this.firstRender && (typeof this.transition === 'object' && !this.transition.appear)) {
-        data.props = {name: '__notranstition__portal-vue__'}
+        data.props = { name: '__notranstition__portal-vue__' }
         return data
       }
 
       if (typeof t === 'string') {
-        data.props = {name: t}
+        data.props = { name: t }
       } else if (typeof t === 'object') {
         data.props = t
       }

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -134,7 +134,7 @@ export default {
     }
 
     // Solves a bug where Vue would sometimes duplicate elements upon changing multiple or disabled
-    const wrapperKey = parseInt(Math.random() * 100)
+    const wrapperKey = this.ownTransports.length
 
     return this.noWrapper
         ? this.children[0]

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -1,6 +1,7 @@
 
-import { transports } from './wormhole'
+// import { transports } from './wormhole'
 import { combinePassengers } from '../utils'
+import wormhole from './wormhole'
 
 export default {
   abstract: true,
@@ -16,7 +17,7 @@ export default {
   },
   data () {
     return {
-      transports,
+      transports: wormhole.transports,
       firstRender: true,
     }
   },
@@ -82,10 +83,6 @@ export default {
       return combinePassengers(this.ownTransports)
     },
     children () {
-      if (this.multiple) {
-        const Tag = this.tag
-        return this.ownTransports.map((transport) => <Tag key={transport.from}>{transport.passengers}</Tag>)
-      }
       return this.passengers.length !== 0 ? this.passengers : (this.$slots.default || [])
     },
     noWrapper () {
@@ -135,8 +132,12 @@ export default {
         </TransitionType>
       )
     }
+
+    // Solves a bug where Vue would sometimes duplicate elements upon changing multiple or disabled
+    const wrapperKey = parseInt(Math.random() * 100)
+
     return this.noWrapper
         ? this.children[0]
-        : <Tag class='vue-portal-target'>{this.children}</Tag>
+        : <Tag class='vue-portal-target' key={wrapperKey}>{this.children}</Tag>
   },
 }

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -82,6 +82,10 @@ export default {
       return combinePassengers(this.ownTransports)
     },
     children () {
+      if (this.multiple) {
+        const Tag = this.tag
+        return this.ownTransports.map((transport) => <Tag key={transport.from}>{transport.passengers}</Tag>)
+      }
       return this.passengers.length !== 0 ? this.passengers : (this.$slots.default || [])
     },
     noWrapper () {
@@ -123,14 +127,16 @@ export default {
   render (h) {
     const TransitionType = this.noWrapper ? 'transition' : 'transition-group'
     const Tag = this.tag
-    const result = this.withTransition
-      ? (<TransitionType {...this.transitionData} class='vue-portal-target'>
+
+    if (this.withTransition) {
+      return (
+        <TransitionType {...this.transitionData} class='vue-portal-target'>
           {this.children}
-        </TransitionType>)
-      : this.noWrapper
+        </TransitionType>
+      )
+    }
+    return this.noWrapper
         ? this.children[0]
         : <Tag class='vue-portal-target'>{this.children}</Tag>
-
-    return result
   },
 }

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -1,5 +1,6 @@
 
 import { transports } from './wormhole'
+import { combinePassengers } from '../utils'
 
 export default {
   abstract: true,
@@ -78,11 +79,7 @@ export default {
       return transports.length === 0 ? [] : [transports[0]]
     },
     passengers () {
-      const passengers = []
-      for (const transport of this.ownTransports) {
-        Array.prototype.push.apply(passengers, transport.passengers)
-      }
-      return passengers
+      return combinePassengers(this.ownTransports)
     },
     children () {
       return this.passengers.length !== 0 ? this.passengers : (this.$slots.default || [])

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -76,7 +76,7 @@ export default {
       if (this.multiple) {
         return transports
       }
-      return transports.length === 0 ? [] : [transports[0]]
+      return transports.length === 0 ? [] : [transports[transports.length - 1]]
     },
     passengers () {
       return combinePassengers(this.ownTransports)

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -6,6 +6,7 @@ export default {
   name: 'portalTarget',
   props: {
     attributes: { type: Object },
+    multiple: { type: Boolean, default: false },
     name: { type: String, required: true },
     slim: { type: Boolean, default: false },
     tag: { type: String, default: 'div' },
@@ -20,7 +21,7 @@ export default {
   },
   mounted () {
     if (!this.transports[this.name]) {
-      this.$set(this.transports, this.name, undefined)
+      this.$set(this.transports, this.name, [])
     }
 
     this.unwatch = this.$watch(function () { return this.transports[this.name] }, this.emitChange)
@@ -69,8 +70,19 @@ export default {
     },
   },
   computed: {
+    ownTransports () {
+      const transports = this.transports[this.name] || []
+      if (this.multiple) {
+        return transports
+      }
+      return transports.length === 0 ? [] : [transports[0]]
+    },
     passengers () {
-      return (this.transports[this.name] && this.transports[this.name].passengers) || []
+      const passengers = []
+      for (const transport of this.ownTransports) {
+        Array.prototype.push.apply(passengers, transport.passengers)
+      }
+      return passengers
     },
     children () {
       return this.passengers.length !== 0 ? this.passengers : (this.$slots.default || [])

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -1,19 +1,18 @@
-
 // import { transports } from './wormhole'
-import { combinePassengers } from '../utils'
+import {combinePassengers} from '../utils'
 import wormhole from './wormhole'
 
 export default {
   abstract: true,
   name: 'portalTarget',
   props: {
-    attributes: { type: Object },
-    multiple: { type: Boolean, default: false },
-    name: { type: String, required: true },
-    slim: { type: Boolean, default: false },
-    tag: { type: String, default: 'div' },
-    transition: { type: [Boolean, String, Object], default: false },
-    transitionEvents: { type: Object, default: () => ({}) },
+    attributes: {type: Object},
+    multiple: {type: Boolean, default: false},
+    name: {type: String, required: true},
+    slim: {type: Boolean, default: false},
+    tag: {type: String, default: 'div'},
+    transition: {type: [Boolean, String, Object], default: false},
+    transitionEvents: {type: Object, default: () => ({})},
   },
   data () {
     return {
@@ -26,7 +25,7 @@ export default {
       this.$set(this.transports, this.name, [])
     }
 
-    this.unwatch = this.$watch(function () { return this.transports[this.name] }, this.emitChange)
+    this.unwatch = this.$watch('ownTransports', this.emitChange)
 
     this.updateAttributes()
     this.$nextTick(() => {
@@ -64,11 +63,20 @@ export default {
         }
       }
     },
-    emitChange (newTransport, oldTransport) {
-      this.$emit('change',
-        { ...newTransport },
-        { ...oldTransport }
-      )
+    emitChange (newTransports, oldTransports) {
+      if (this.multiple) {
+        this.$emit('change',
+          [...newTransports],
+          [...oldTransports]
+        )
+      } else {
+        const newTransport = newTransports.length === 0 ? undefined : newTransports[0]
+        const oldTransport = oldTransports.length === 0 ? undefined : oldTransports[0]
+        this.$emit('change',
+          { ...newTransport },
+          { ...oldTransport }
+        )
+      }
     },
   },
   computed: {
@@ -103,12 +111,12 @@ export default {
       // We have to do this to emulate the normal behaviour of transitions without `appear`
       // because in Portals, transitions can behave as if appear was defined under certain conditions.
       if (this.firstRender && (typeof this.transition === 'object' && !this.transition.appear)) {
-        data.props = { name: '__notranstition__portal-vue__' }
+        data.props = {name: '__notranstition__portal-vue__'}
         return data
       }
 
       if (typeof t === 'string') {
-        data.props = { name: t }
+        data.props = {name: t}
       } else if (typeof t === 'object') {
         data.props = t
       }
@@ -137,7 +145,7 @@ export default {
     const wrapperKey = this.ownTransports.length
 
     return this.noWrapper
-        ? this.children[0]
-        : <Tag class='vue-portal-target' key={wrapperKey}>{this.children}</Tag>
+      ? this.children[0]
+      : <Tag class='vue-portal-target' key={wrapperKey}>{this.children}</Tag>
   },
 }

--- a/src/components/portal-target.js
+++ b/src/components/portal-target.js
@@ -20,11 +20,12 @@ export default {
       firstRender: true,
     }
   },
-  mounted () {
+  created () {
     if (!this.transports[this.name]) {
       this.$set(this.transports, this.name, [])
     }
-
+  },
+  mounted () {
     this.unwatch = this.$watch('ownTransports', this.emitChange)
 
     this.updateAttributes()

--- a/src/components/portal.js
+++ b/src/components/portal.js
@@ -15,6 +15,7 @@ export default {
     /* global HTMLElement */
     disabled: { type: Boolean, default: false },
     name: { type: String, default: () => String(pid++) },
+    order: { type: Number, default: 0 },
     slim: { type: Boolean, default: false },
     tag: { type: [String], default: 'DIV' },
     targetEl: { type: inBrowser ? [String, HTMLElement] : String },
@@ -64,6 +65,7 @@ export default {
             from: this.name,
             to: this.to,
             passengers: [...this.$slots.default],
+            order: this.order,
           })
         }
       } else if (!this.to && !this.targetEl) {

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -15,11 +15,10 @@ export class Wormhole {
 
     transport.passengers = freeze(passengers)
     const keys = Object.keys(this.transports)
-    if (keys.indexOf(to) !== -1) {
-      this.transports[to] = transport
-    } else {
-      Vue.set(this.transports, to, transport)
+    if (keys.indexOf(to) === -1) {
+      Vue.set(this.transports, to, [])
     }
+    this.transports[to].push(transport)
   }
 
   close (transport, force = false) {

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -18,14 +18,24 @@ export class Wormhole {
     if (keys.indexOf(to) === -1) {
       Vue.set(this.transports, to, [])
     }
-    this.transports[to].push(transport)
+    if (this.getTransportIndex(transport) === -1) {
+      this.transports[to].push(transport)
+    }
   }
 
   close (transport, force = false) {
     const { to, from } = transport
     if (!to || !from) return
-    if (this.transports[to] && (force || this.transports[to].from === from)) {
-      this.transports[to] = undefined
+    if (!this.transports[to]) {
+      return
+    }
+    if (force) {
+      this.transports[to] = []
+    } else {
+      const index = this.getTransportIndex(transport)
+      if (index >= 0) {
+        this.transports[to].splice(index, 1)
+      }
     }
   }
 
@@ -47,6 +57,15 @@ export class Wormhole {
   getContentFor (to) {
     const transport = this.transports[to]
     return transport ? transport.passengers : undefined
+  }
+
+  getTransportIndex ({ to, from }) {
+    for (const i in this.transports[to]) {
+      if (this.transports[to][i].from === from) {
+        return i
+      }
+    }
+    return -1
   }
 }
 const wormhole = new Wormhole(transports)

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -23,8 +23,13 @@ export class Wormhole {
     if (currentIndex === -1) {
       this.transports[to].push(transport)
     } else {
-      this.transports[to][currentIndex].passengers = passengers
+      this.transports[to][currentIndex] = transport
     }
+
+    this.transports[to].sort(function (a, b) {
+      console.log(a.order - b.order)
+      return a.order - b.order
+    })
   }
 
   close (transport, force = false) {

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -27,7 +27,6 @@ export class Wormhole {
     }
 
     this.transports[to].sort(function (a, b) {
-      console.log(a.order - b.order)
       return a.order - b.order
     })
   }

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -20,15 +20,18 @@ export class Wormhole {
     }
 
     const currentIndex = this.getTransportIndex(transport)
+    // Copying the array here so that the PortalTarget change event will actually contain two distinct arrays
+    const newTransports = this.transports[to].slice(0)
     if (currentIndex === -1) {
-      this.transports[to].push(transport)
+      newTransports.push(transport)
     } else {
-      this.transports[to][currentIndex] = transport
+      newTransports[currentIndex] = transport
     }
-
-    this.transports[to].sort(function (a, b) {
+    newTransports.sort(function (a, b) {
       return a.order - b.order
     })
+
+    this.transports[to] = newTransports
   }
 
   close (transport, force = false) {
@@ -43,7 +46,10 @@ export class Wormhole {
     } else {
       const index = this.getTransportIndex(transport)
       if (index >= 0) {
-        this.transports[to].splice(index, 1)
+        // Copying the array here so that the PortalTarget change event will actually contain two distinct arrays
+        const newTransports = this.transports[to].slice(0)
+        newTransports.splice(index, 1)
+        this.transports[to] = newTransports
       }
     }
   }

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { freeze } from '../utils'
+import { combinePassengers, freeze } from '../utils'
 const transports = {}
 
 export { transports }
@@ -44,19 +44,22 @@ export class Wormhole {
   }
 
   hasContentFor (to) {
-    /* eslint no-unneeded-ternary: 0 */
-    return this.transports[to] && this.transports[to].passengers != null
-      ? true
-      : false
+    if (!this.transports[to]) {
+      return false
+    }
+    return this.getContentFor(to).length > 0
   }
 
   getSourceFor (to) {
-    return this.transports[to] && this.transports[to].from
+    return this.transports[to] && this.transports[to][0].from
   }
 
   getContentFor (to) {
-    const transport = this.transports[to]
-    return transport ? transport.passengers : undefined
+    const transports = this.transports[to]
+    if (!transports) {
+      return undefined
+    }
+    return combinePassengers(transports)
   }
 
   getTransportIndex ({ to, from }) {

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -19,8 +19,11 @@ export class Wormhole {
       Vue.set(this.transports, to, [])
     }
 
-    if (this.getTransportIndex(transport) === -1) {
+    const currentIndex = this.getTransportIndex(transport)
+    if (currentIndex === -1) {
       this.transports[to].push(transport)
+    } else {
+      this.transports[to][currentIndex].passengers = passengers
     }
   }
 

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -18,6 +18,7 @@ export class Wormhole {
     if (keys.indexOf(to) === -1) {
       Vue.set(this.transports, to, [])
     }
+
     if (this.getTransportIndex(transport) === -1) {
       this.transports[to].push(transport)
     }
@@ -29,6 +30,7 @@ export class Wormhole {
     if (!this.transports[to]) {
       return
     }
+
     if (force) {
       this.transports[to] = []
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,3 +16,11 @@ export function freeze (item) {
   }
   return item
 }
+
+export function combinePassengers (transports) {
+  const passengers = []
+  for (const transport of transports) {
+    Array.prototype.push.apply(passengers, transport.passengers)
+  }
+  return passengers
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,9 +18,9 @@ export function freeze (item) {
 }
 
 export function combinePassengers (transports) {
-  const passengers = []
+  let passengers = []
   for (const transport of transports) {
-    Array.prototype.push.apply(passengers, transport.passengers)
+    passengers = passengers.concat(transport.passengers)
   }
   return passengers
 }

--- a/test/unit/portal-target.spec.js
+++ b/test/unit/portal-target.spec.js
@@ -1,4 +1,4 @@
-import {expect, td} from './helpers'
+import { expect, td } from './helpers'
 import Vue from 'vue'
 
 const PortalTargetInj = require('!!inject-loader!babel-loader!../../src/components/portal-target.js')
@@ -6,7 +6,7 @@ const PortalTargetInj = require('!!inject-loader!babel-loader!../../src/componen
 const transports = {}
 
 const PortalTarget = new PortalTargetInj({
-  './wormhole': {transports: transports},
+  './wormhole': { transports: transports },
 }).default
 
 // Utils
@@ -27,7 +27,7 @@ function generateVNode () {
     el,
     render (h) {
       __id++
-      return h('div', [h('span', {key: `key-${__id}`, class: 'testnode'}, 'Test')])
+      return h('div', [h('span', { key: `key-${__id}`, class: 'testnode' }, 'Test')])
     },
   })
   return vm._vnode.children
@@ -72,7 +72,7 @@ describe('PortalTarget', function () {
         from: 'test-portal',
         to: 'target',
         passengers: vNodes,
-      }
+      },
     ])
 
     const vm = generateTarget({
@@ -118,7 +118,7 @@ describe('PortalTarget', function () {
 
   it('renders slot content when no other content is available', function () {
     const vm = new Vue({
-      components: {PortalTarget},
+      components: { PortalTarget },
       template: `
         <portal-target name="target">
           <p class="default">This is the default content</p>
@@ -133,12 +133,12 @@ describe('PortalTarget', function () {
     })
   })
 
-  it('emits change event with correct payload', function () {
+  it('emits change event with the new last transport and old last transport when multiple is true', function () {
     const spy = td.function('changeHandler') // {}
     /* eslint no-unused-vars: 0 */
     const el = document.createElement('DIV')
     const vm = new Vue({
-      components: {PortalTarget},
+      components: { PortalTarget },
       template: `<portal-target name="target" @change="handler"/>`,
       methods: {
         handler: spy,
@@ -152,9 +152,36 @@ describe('PortalTarget', function () {
     })
     return vm.$nextTick().then(() => {
       td.verify(spy({
-          to: 'target', from: 'source', passengers: vNodes
+          to: 'target', from: 'source', passengers: vNodes,
         },
-        {}
+        {},
+      ))
+      vm.$destroy()
+    })
+  })
+
+  it('emits change event with the new and old transports when multiple is true', function () {
+    const spy = td.function('changeHandler') // {}
+    /* eslint no-unused-vars: 0 */
+    const el = document.createElement('DIV')
+    const vm = new Vue({
+      components: { PortalTarget },
+      template: `<portal-target name="target" @change="handler"/>`,
+      methods: {
+        handler: spy,
+      },
+    }).$mount(el)
+    const vNodes = Object.freeze([generateVNode()[0], generateVNode()[0]])
+    Vue.set(transports, 'target', {
+      to: 'target',
+      from: 'source',
+      passengers: vNodes,
+    })
+    return vm.$nextTick().then(() => {
+      td.verify(spy({
+          to: 'target', from: 'source', passengers: vNodes,
+        },
+        {},
       ))
       vm.$destroy()
     })
@@ -170,7 +197,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: {PortalTarget},
+      components: { PortalTarget },
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade'}"
@@ -205,7 +232,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: {PortalTarget},
+      components: { PortalTarget },
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade'}"
@@ -224,7 +251,7 @@ describe('PortalTarget', function () {
       passengers: vNode,
     })
     return vm.$nextTick().then(() => {
-      td.verify(spy(), {times: 0, ignoreExtraArgs: true})
+      td.verify(spy(), { times: 0, ignoreExtraArgs: true })
       vm.$destroy()
     })
   })
@@ -236,7 +263,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: {PortalTarget},
+      components: { PortalTarget },
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade', appear: true}"

--- a/test/unit/portal-target.spec.js
+++ b/test/unit/portal-target.spec.js
@@ -255,11 +255,11 @@ describe('PortalTarget', function () {
 
     const vNode = Object.freeze(generateVNode())
 
-    Vue.set(transports, 'target', {
+    Vue.set(transports, 'target', [{
       to: 'target',
       from: 'source',
       passengers: vNode,
-    })
+    }])
     return vm.$nextTick().then(() => {
       td.verify(spy(), { times: 0, ignoreExtraArgs: true })
       vm.$destroy()
@@ -286,11 +286,11 @@ describe('PortalTarget', function () {
 
     const vNode = Object.freeze([generateVNode()])
 
-    Vue.set(transports, 'target', {
+    Vue.set(transports, 'target', [{
       to: 'target',
       from: 'source',
       passengers: vNode,
-    })
+    }])
     return vm.$nextTick().then(() => {
       td.verify(spy(td.matchers.isA(HTMLElement), td.matchers.isA(Function)))
       vm.$destroy()

--- a/test/unit/portal-target.spec.js
+++ b/test/unit/portal-target.spec.js
@@ -1,11 +1,12 @@
-import { expect, td } from './helpers'
+import {expect, td} from './helpers'
 import Vue from 'vue'
+
 const PortalTargetInj = require('!!inject-loader!babel-loader!../../src/components/portal-target.js')
 
 const transports = {}
 
 const PortalTarget = new PortalTargetInj({
-  './wormhole': { transports: transports },
+  './wormhole': {transports: transports},
 }).default
 
 // Utils
@@ -19,13 +20,14 @@ function generateTarget (props) {
 }
 
 let __id = 0
+
 function generateVNode () {
   const el = document.createElement('DIV')
   const vm = new Vue({
     el,
     render (h) {
       __id++
-      return h('div', [h('span', { key: `key-${__id}`, class: 'testnode' }, 'Test')])
+      return h('div', [h('span', {key: `key-${__id}`, class: 'testnode'}, 'Test')])
     },
   })
   return vm._vnode.children
@@ -44,11 +46,13 @@ describe('PortalTarget', function () {
 
   it('renders a single element for single vNode with slim prop & single slot element', () => {
     const vNode = Object.freeze(generateVNode())
-    Vue.set(transports, 'target', {
-      from: 'target-portal',
-      to: 'target',
-      passengers: vNode,
-    })
+    Vue.set(transports, 'target', [
+      {
+        from: 'target-portal',
+        to: 'target',
+        passengers: vNode,
+      },
+    ])
 
     const vm = generateTarget({
       name: 'target',
@@ -63,11 +67,13 @@ describe('PortalTarget', function () {
 
   it('renders a wrapper with class `vue-portal-target` for multiple vNodes', () => {
     const vNodes = Object.freeze([generateVNode()[0], generateVNode()[0]])
-    Vue.set(transports, 'target', {
-      from: 'test-portal',
-      to: 'target',
-      passengers: vNodes,
-    })
+    Vue.set(transports, 'target', [
+      {
+        from: 'test-portal',
+        to: 'target',
+        passengers: vNodes,
+      }
+    ])
 
     const vm = generateTarget({
       name: 'target',
@@ -82,11 +88,13 @@ describe('PortalTarget', function () {
 
   it('applies attributes correctly to root node', () => {
     const vNodes = Object.freeze([generateVNode()[0], generateVNode()[0]])
-    Vue.set(transports, 'target', {
-      from: 'test-portal',
-      to: 'target',
-      passengers: vNodes,
-    })
+    Vue.set(transports, 'target', [
+      {
+        from: 'test-portal',
+        to: 'target',
+        passengers: vNodes,
+      },
+    ])
 
     const vm = generateTarget({
       name: 'target',
@@ -110,7 +118,7 @@ describe('PortalTarget', function () {
 
   it('renders slot content when no other content is available', function () {
     const vm = new Vue({
-      components: { PortalTarget },
+      components: {PortalTarget},
       template: `
         <portal-target name="target">
           <p class="default">This is the default content</p>
@@ -130,7 +138,7 @@ describe('PortalTarget', function () {
     /* eslint no-unused-vars: 0 */
     const el = document.createElement('DIV')
     const vm = new Vue({
-      components: { PortalTarget },
+      components: {PortalTarget},
       template: `<portal-target name="target" @change="handler"/>`,
       methods: {
         handler: spy,
@@ -144,7 +152,8 @@ describe('PortalTarget', function () {
     })
     return vm.$nextTick().then(() => {
       td.verify(spy({
-        to: 'target', from: 'source', passengers: vNodes },
+          to: 'target', from: 'source', passengers: vNodes
+        },
         {}
       ))
       vm.$destroy()
@@ -161,7 +170,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: { PortalTarget },
+      components: {PortalTarget},
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade'}"
@@ -175,11 +184,13 @@ describe('PortalTarget', function () {
     const vNode = Object.freeze(generateVNode())
 
     return vm.$nextTick().then(() => { // needed so the portal-target can mount.
-      Vue.set(transports, 'target', {
-        to: 'target',
-        from: 'source',
-        passengers: vNode,
-      })
+      Vue.set(transports, 'target', [
+        {
+          to: 'target',
+          from: 'source',
+          passengers: vNode,
+        },
+      ])
       return vm.$nextTick().then(() => {
         td.verify(spy(td.matchers.isA(HTMLElement), td.matchers.isA(Function)))
         vm.$destroy()
@@ -194,7 +205,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: { PortalTarget },
+      components: {PortalTarget},
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade'}"
@@ -213,7 +224,7 @@ describe('PortalTarget', function () {
       passengers: vNode,
     })
     return vm.$nextTick().then(() => {
-      td.verify(spy(), { times: 0, ignoreExtraArgs: true })
+      td.verify(spy(), {times: 0, ignoreExtraArgs: true})
       vm.$destroy()
     })
   })
@@ -225,7 +236,7 @@ describe('PortalTarget', function () {
       created () {
         this.spy = spy
       },
-      components: { PortalTarget },
+      components: {PortalTarget},
       template: `
         <portal-target name="target" ref="target"
           :transition="{name: 'fade', appear: true}"

--- a/test/unit/portal-target.spec.js
+++ b/test/unit/portal-target.spec.js
@@ -1,4 +1,4 @@
-import {expect, td} from './helpers'
+import { expect, td } from './helpers'
 import Vue from 'vue'
 
 const PortalTargetInj = require('!!inject-loader!babel-loader!../../src/components/portal-target.js')
@@ -152,8 +152,8 @@ describe('PortalTarget', function () {
     }])
     return vm.$nextTick().then(() => {
       td.verify(spy({
-          to: 'target', from: 'source', passengers: vNodes,
-        },
+        to: 'target', from: 'source', passengers: vNodes,
+      },
         {},
       ))
       vm.$destroy()

--- a/test/unit/wormhole.spec.js
+++ b/test/unit/wormhole.spec.js
@@ -1,6 +1,6 @@
 /* global describe it beforeEach */
-import { expect } from './helpers'
-import { Wormhole } from '../../src/components/wormhole'
+import {expect} from './helpers'
+import {Wormhole} from '../../src/components/wormhole'
 
 let wormhole
 
@@ -18,11 +18,13 @@ describe('Wormhole', function () {
     })
 
     expect(wormhole.transports).to.deep.equal({
-      target: {
-        from: 'test-portal',
-        to: 'target',
-        passengers: ['Test'],
-      },
+      target: [
+        {
+          from: 'test-portal',
+          to: 'target',
+          passengers: ['Test'],
+        },
+      ],
     })
   })
 
@@ -35,13 +37,13 @@ describe('Wormhole', function () {
     }
 
     wormhole.open(content)
-    expect(wormhole.transports).to.deep.equal({ target: content })
+    expect(wormhole.transports).to.deep.equal({target: [content]})
 
     wormhole.close({
       from: 'test-portal',
       to: 'target',
     })
-    expect(wormhole.transports).to.deep.equal({ target: undefined })
+    expect(wormhole.transports).to.deep.equal({target: []})
   })
 
   it('only closes transports from the same source portal', () => {
@@ -62,15 +64,17 @@ describe('Wormhole', function () {
       to: 'target',
     })
     expect(wormhole.transports).to.deep.equal({
-      target: {
-        from: 'test-portal2',
-        to: 'target',
-        passengers: ['Test2'],
-      },
+      target: [
+        {
+          from: 'test-portal2',
+          to: 'target',
+          passengers: ['Test2'],
+        },
+      ],
     })
   })
 
-  it('closes transports from the other source portals when force=true', () => {
+  it('closes all transports to the same target when force=true', () => {
     wormhole.open({
       from: 'test-portal1',
       to: 'target',
@@ -87,7 +91,7 @@ describe('Wormhole', function () {
       from: 'test-portal1',
       to: 'target',
     }, true) // force argument
-    expect(wormhole.transports).to.deep.equal({ target: undefined })
+    expect(wormhole.transports).to.deep.equal({target: []})
   })
 
   it('hasTarget()', function () {

--- a/test/unit/wormhole.spec.js
+++ b/test/unit/wormhole.spec.js
@@ -1,6 +1,6 @@
 /* global describe it beforeEach */
-import {expect} from './helpers'
-import {Wormhole} from '../../src/components/wormhole'
+import { expect } from './helpers'
+import { Wormhole } from '../../src/components/wormhole'
 
 let wormhole
 
@@ -37,13 +37,13 @@ describe('Wormhole', function () {
     }
 
     wormhole.open(content)
-    expect(wormhole.transports).to.deep.equal({target: [content]})
+    expect(wormhole.transports).to.deep.equal({ target: [content] })
 
     wormhole.close({
       from: 'test-portal',
       to: 'target',
     })
-    expect(wormhole.transports).to.deep.equal({target: []})
+    expect(wormhole.transports).to.deep.equal({ target: [] })
   })
 
   it('only closes transports from the same source portal', () => {
@@ -91,7 +91,7 @@ describe('Wormhole', function () {
       from: 'test-portal1',
       to: 'target',
     }, true) // force argument
-    expect(wormhole.transports).to.deep.equal({target: []})
+    expect(wormhole.transports).to.deep.equal({ target: [] })
   })
 
   it('hasTarget()', function () {


### PR DESCRIPTION
Adds a multiple prop to the portal-target that, when true, will display all portals with the same target instead of just the first one.

Haven't written any tests yet, but I'll gladly add some if there's a real chance this PR might be accepted.