### PR TITLE
Close wormhole when portal empty

### DIFF
--- a/example/components/router-view-with-portals/a.vue
+++ b/example/components/router-view-with-portals/a.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <portal to="title">Page A</portal>
+    <p>
+      The contents of Page A.
+    </p>
+  </div>
+</template>

--- a/example/components/router-view-with-portals/b.vue
+++ b/example/components/router-view-with-portals/b.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <portal to="title">Page B</portal>
+    <p>
+      The contents of Page B.
+    </p>
+  </div>
+</template>

--- a/example/components/router-view-with-portals/index.vue
+++ b/example/components/router-view-with-portals/index.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <h1><portal-target name="title">Home</portal-target></h1>
+    <router-link to="/router-view-with-portals">Home</router-link>
+    <router-link to="/router-view-with-portals/a">a</router-link>
+    <router-link to="/router-view-with-portals/b">b</router-link>
+    <p>
+      This page has two sub-routes, "Page A" and "Page B". Both of the routes
+      have a portal that will teleport the title of the sub-route to the header
+      on the parent route. If neither sub-route is active, it uses the default
+      title.
+    </p>
+    <p>
+      This allows sub-routes to set page elements in parent routes.
+    </p>
+
+    <p><strong><code>router-view</code> contents:</strong></p>
+
+    <div class="router-view-box">
+      <router-view />
+    </div>
+  </div>
+</template>
+
+<style>
+  .router-view-box {
+    border: 1px solid black;
+    padding: 10px;
+  }
+</style>

--- a/example/router.js
+++ b/example/router.js
@@ -7,6 +7,9 @@ import SourceSwitch from './components/source-switch/source-switch.vue'
 import Disabled from './components/disabled'
 import CompAsRoot from './components/comp-as-root/comp-as-root.vue'
 import Programmatic from './components/programmatic/index.vue'
+import RouterViewWithPortals from './components/router-view-with-portals/index.vue'
+import RouterViewWithPortalsA from './components/router-view-with-portals/a.vue'
+import RouterViewWithPortalsB from './components/router-view-with-portals/b.vue'
 import MountToExternal from './components/mount-to/mount-to-external.vue'
 import EmptyPortal from './components/empty-portal/index.vue'
 import DefaultSlotContent from './components/default-content-on-target/index.vue'
@@ -46,6 +49,14 @@ const routes = [
   {
     path: '/programmatic',
     component: Programmatic,
+  },
+  {
+    path: '/router-view-with-portals',
+    component: RouterViewWithPortals,
+    children: [
+      { path: 'a', component: RouterViewWithPortalsA },
+      { path: 'b', component: RouterViewWithPortalsB },
+    ],
   },
   {
     path: '/default-slot-content-for-target',

--- a/src/components/portal.js
+++ b/src/components/portal.js
@@ -65,6 +65,8 @@ export default {
             to: this.to,
             passengers: [...this.$slots.default],
           })
+        } else {
+          this.clear()
         }
       } else if (!this.to && !this.targetEl) {
         console.warn('[vue-portal]: You have to define a target via the `to` prop.')


### PR DESCRIPTION
This pull request resloves #85.

Also includes a practical example of using sub-routes with portals in them. This example actually *does* work without this fix. I had just made the example while working on the fix and thought that it was useful. I could put the example in another PR if that would be better.