### PR TITLE
fix: use stableSort routine when sorting transports. Fixes #152, #141

### DIFF
--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { combinePassengers, freeze } from '../utils'
+import { combinePassengers, freeze, stableSort } from '../utils'
 const transports = {}
 
 export { transports }
@@ -25,7 +25,7 @@ export const Wormhole = Vue.extend({
       } else {
         newTransports[currentIndex] = transport
       }
-      newTransports.sort(function(a, b) {
+      newTransports = stableSort(newTransports, function(a, b) {
         return a.order - b.order
       })
 

--- a/src/components/wormhole.js
+++ b/src/components/wormhole.js
@@ -25,11 +25,9 @@ export const Wormhole = Vue.extend({
       } else {
         newTransports[currentIndex] = transport
       }
-      newTransports = stableSort(newTransports, function(a, b) {
+      this.transports[to] = stableSort(newTransports, function(a, b) {
         return a.order - b.order
       })
-
-      this.transports[to] = newTransports
     },
 
     close(transport, force = false) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,6 +45,6 @@ export function combinePassengers(transports, slotProps = {}) {
 export function stableSort(array, compareFn) {
   return array
     .map((v, idx) => [ idx, v])
-    .sort(function (a,b) { return this(a[1], b[a]) || a[0] - b[0] }.bind(compareFn))
+    .sort(function (a,b) { return this(a[1], b[1]) || a[0] - b[0] }.bind(compareFn))
     .map(c => c[1])
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ export function combinePassengers(transports, slotProps = {}) {
 
 export function stableSort(array, compareFn) {
   return array
-    .map((v, idx) => [ idx, v])
+    .map((v, idx) => [idx, v])
     .sort(function (a,b) { return this(a[1], b[1]) || a[0] - b[0] }.bind(compareFn))
     .map(c => c[1])
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,3 +41,10 @@ export function combinePassengers(transports, slotProps = {}) {
     return passengers.concat(newPassengers)
   }, [])
 }
+
+export function stableSort(array, compareFn) {
+  return array
+    .map((v, idx) => [ idx, v])
+    .sort(function (a,b) { return this(a[1], b[a]) || a[0] - b[0] }.bind(compareFn))
+    .map(c => c[1])
+}


### PR DESCRIPTION
Uses stable sort routine rather than native `Array.prototype.sort` to ensure a consistent sort across browser platforms and array sizes... (I'm looking at you Chrome :imp: )

Stable Sort preserves original array order when elements end up with a compare result of `0`, by comparing by the original position (index) in the original array.

Fixes #152, and most likely #141