### PR TITLE
Removes name attr from rendering outside app example

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -204,7 +204,7 @@ One important behaviour to know is this:
 ```html
 <body>
   <div id="app">
-    <portal name="" target-el="#widget">
+    <portal target-el="#widget">
       <p>
         PortalVue will dynamically mount an  instance of <portal-target> in place of the Element
         with `id="widget"`, and this paragraph will be rendered inside of it.


### PR DESCRIPTION
Hey! 

I was stuck with this for quite a bit actually and figured rendering a portal outside the Vue app doesn't work when `name=""` is provided as showcased in the example. This removes the attribute from the example. 

Alternatively, I could also add a short sentence mentioning this issue (side effect?).