### PR TITLE
docs: fix portal-target transition component example

### DIFF
--- a/docs/api/portal-target.md
+++ b/docs/api/portal-target.md
@@ -154,7 +154,7 @@ plain wrapper element that is usually rendered.
 
 It accepts:
 
-- a `String` value: will render `<transition-group>` with the `name` prop set to that string.
+- a `String` value: will render a globally registered component of this name.
 - a `Component`: will render `<transition-group>` with the object's content passed as props.
 
 Example with string:
@@ -168,7 +168,7 @@ Example with string:
 </portal-target>
 ```
 
-Example with Component
+Example with Component:
 
 <!-- prettier-ignore -->
 ```html
@@ -183,8 +183,8 @@ computed: {
   fadeTransition() {
     return {
       functional: true,
-      render(h) {
-        h('transition', { name: 'fade', mode: 'out-in' })
+      render(h, context) {
+        return h('transition', { props: { name: 'fade', mode: 'out-in' } }, context.children)
       }
     }
   },


### PR DESCRIPTION
I was following https://portal-vue.linusb.org/api/portal-target.html#transition to upgrade to 2.0.0, and found I needed to make the following changes to get the transition component working:
- `render` function should return
- `props` should be nested in `h`'s data object
- `children` should be passed from `context`

Hopefully this is helpful. Thank you for the awesome library!