### PR TITLE
Fix API and Guide links that were mixed around

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -40,8 +40,8 @@ Setting a Transition for the `<PortalTarget>` now requires a locally or globally
 
 More info:
 
-- [Guide](../api/portal-target.md#transistion)
-- [API Docs](./advanced.md#transitions)
+- [Guide](./advanced.md#transitions)
+- [API Docs](../api/portal-target.md#transistion)
 
 ### PortalTarget `@change` event
 


### PR DESCRIPTION
In the migration guide for transitions, the more info links for "Guide" was pointing to the API docs, and the "API Docs" link was pointing to the guide.