### PR TITLE
fix: Wormhole.close force=true and from=undefined

### DIFF
--- a/src/components/wormhole.ts
+++ b/src/components/wormhole.ts
@@ -54,7 +54,7 @@ export const Wormhole = Vue.extend({
 
     close(transport: TransportVector, force = false) {
       const { to, from } = transport
-      if (!to || !from) return
+      if (!to || (!from && force === false)) return
       if (!this.transports[to]) {
         return
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export interface Transport {
 
 export interface TransportVector {
   to: string
-  from: string
+  from?: string
 }
 
 export type PropWithComponent =

--- a/tests/unit/specs/wormhole.spec.js
+++ b/tests/unit/specs/wormhole.spec.js
@@ -100,6 +100,44 @@ describe('Wormhole', function() {
     expect(wormhole.transports).toEqual({ target: [] })
   })
 
+  it('removes content on close() when force=true and from=undefined', () => {
+    wormhole.open({
+      from: 'test-portal',
+      to: 'target',
+      passengers: ['Test'],
+    })
+
+    wormhole.close(
+      {
+        to: 'target',
+      },
+      true
+    ) // force argument
+    expect(wormhole.transports).toEqual({ target: [] })
+  })
+
+  it('closes all transports to the same target when force=true and from=undefined', () => {
+    wormhole.open({
+      from: 'test-portal1',
+      to: 'target',
+      passengers: ['Test1'],
+    })
+
+    wormhole.open({
+      from: 'test-portal2',
+      to: 'target',
+      passengers: ['Test2'],
+    })
+
+    wormhole.close(
+      {
+        to: 'target',
+      },
+      true
+    ) // force argument
+    expect(wormhole.transports).toEqual({ target: [] })
+  })
+
   it('hasTarget()', function() {
     const check1 = wormhole.hasTarget('target')
     expect(check1).toBe(false)

--- a/types/lib/types.d.ts
+++ b/types/lib/types.d.ts
@@ -22,7 +22,7 @@ export interface Transport {
 }
 export interface TransportVector {
     to: string;
-    from: string;
+    from?: string;
 }
 export declare type PropWithComponent = VueConstructor<Vue> | ComponentOptions<Vue> | string;
 export declare type PortalProps = Partial<{


### PR DESCRIPTION
According to the documentation, the parameter `from` is optional when `force = true`.

https://portal-vue.linusb.org/api/wormhole.html#close

There is three locations of this in the documentation

First in the parameters table, `from` is marked as not required.

```
Name of the Portal that the content was created with. Can be left out if the force flag is set
```

Secondly in this sentence: 

```
Why do you have to provide the from name (or use force)?
```

And then in the example (variation with `force`)

```js
// Variation with `force`
Wormhole.close({
    to: 'destination',
}, true)
```