### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/api/portal.md
+++ b/docs/api/portal.md
@@ -17,7 +17,7 @@ Wrap any content that you want to render somewhere else in a `<Portal>` componen
   target-el="#target"
   :disabled="isDisabled"
 >
-  <p>This coonent will be sent through the portal</p>
+  <p>This content will be sent through the portal</p>
 </portal>
 ```
 
@@ -29,7 +29,7 @@ Wrap any content that you want to render somewhere else in a `<Portal>` componen
 | --------- | -------- | ------- |
 | `Boolean` | no       | `false` |
 
-When `true`, the slot content will _not_ be send through the portal to the defined PortalTarget.
+When `true`, the slot content will _not_ be sent through the portal to the defined PortalTarget.
 
 Instead, it will be rendered in place:
 
@@ -156,7 +156,7 @@ It has a (more useful) counterpart in the `<portal-target>` component
 
 <!-- prettier-ignore -->
 ```html
-<div class="vue-portal"><p>This scoped slot content is disabled</p></div>
+<div class="vue-portal"><p>This scoped slot content is disabled!</p></div>
 ```
 
 ### `tag`

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -37,7 +37,7 @@ PortalVue is available through a couple of CDNs, I recommend
 Just include the script tag _after_ the one of Vue.js
 
 ```html
-<scipt src="http://unpkg.com/vue/dist/vue.js"></scipt>
+<script src="http://unpkg.com/vue/dist/vue.js"></script>
 <script src="http://unpkg.com/portal-vue"></script>
 ```
 
@@ -113,16 +113,16 @@ When including Portal-vue from a CDN, make sure you get one of the of UMD builds
 
 **About CDNs**: `unpkg.com` and `jsdelivr.com` will load the umd lib automatically.
 
-If you include it form other sources directly in you HTML, make sure to import `portal-vue/dist/portal-vue.umd.min.js`
+If you include it from other sources directly in your HTML, make sure to import `portal-vue/dist/portal-vue.umd.min.js`
 
 ### Commonjs
 
-This is the defaulf main file of the package.
+This is the default main file of the package.
 
-Webpack 1 doesn't support commonjs, neither do some dev tools, like jest don't either. So this is a sensible default to use.
+Webpack 1 doesn't support commonjs, neither do some dev tools, like jest doesn't either. So this is a sensible default to use.
 
 ### ESM
 
 Webpack >=2, rollup and parcel all can natively understand ESModules, so this is the best build to use with those bundlers.
 
-The ESM version is marked as the default export of `package.json` for consumers that understand the `"module"` field in `package.json` (which is true for all the aforementioned bundlers), so doing `import PortalVue from 'portal-vue'` will automatically give your the ESM build if the bundler supports it.
+The ESM version is marked as the default export of `package.json` for consumers that understand the `"module"` field in `package.json` (which is true for all the aforementioned bundlers), so doing `import PortalVue from 'portal-vue'` will automatically give you the ESM build if the bundler supports it.


### PR DESCRIPTION
In case the 'disabled!' change isn't self-explanatory, the example has the value of `state` set to 'disabled!' but the result was without the exclamation mark.