### PR TITLE
Improve docs.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ sidebar: false
 
 <portal-target name="destination">
   <!--
-  This component can be located anwhere in your App
-  (i.e. right before the </body> tag, for good for overlays).
+  This component can be located anywhere in your App
+  (e.g. for overlays one could put it right before the </body> tag).
   The slot content of the above portal component will be rendered here.
   -->
 </portal-target>


### PR DESCRIPTION
- typo on anywhere
- e.g. to provide example, instead of i.e. (in other words).