### PR TITLE
update vue peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "types": "./types/index.d.ts",
   "peerDependencies": {
-    "vue": "^2.5.18"
+    "vue": ">= 2.5.18 < 3"
   },
   "devDependencies": {
     "@babel/runtime-corejs2": "^7.1.5",


### PR DESCRIPTION
Hello

I'm using portal-vue as a dependency of a UI library in vue and when installing this library in a project running the latest version of vue I have this warning:

```
npm WARN portal-vue@2.1.4 requires a peer of vue@^2.5.18 but none is installed. You must install peer dependencies yourself.
```

This project that I'm installing my library into is running the latest version of vue which is `2.6.10`.

Based on [npm's documentation of peerDependency](https://docs.npmjs.com/files/package.json#peerdependencies) the package.json is waiting for vue `2.5.18` only.

I updated the version to allow vue `2.5.18` and forward excluding the next major version.