### PR TITLE
docs(api): fix order type in the portal component

### DIFF
--- a/docs/api/portal.md
+++ b/docs/api/portal.md
@@ -69,9 +69,9 @@ But it might be a good idea to name your `<Portal>` components so you can debug 
 
 ### `order` <Badge text="1.2.0+"/>
 
-| Type              | Required | Default         |
-| ----------------- | -------- | --------------- |
-| `[String,Number]` | no\*     | a random String |
+| Type     | Required | Default |
+| -------- | -------- | ------- |
+| `Number` | no\*     | 0       |
 
 This prop defines the order position in the output of the `<PortalTarget>`.
 


### PR DESCRIPTION
Ref: https://github.com/LinusBorg/portal-vue/blob/develop/src/components/portal.tsx#L13