### PR TITLE
Fix small typos in docs

### DIFF
--- a/docs/api/mounting-portal.md
+++ b/docs/api/mounting-portal.md
@@ -6,7 +6,7 @@ next: ./wormhole
 
 # MountingPortal
 
-This component extends the behaviour of a normal `<Portal>` by also mounting a `<PortalTarget>` to a DOM Element that the developer specifics with a _selector string_. (i.e. `#target-id`).
+This component extends the behaviour of a normal `<Portal>` by also mounting a `<PortalTarget>` to a DOM Element that the developer specifies with a _selector string_. (i.e. `#target-id`).
 
 It also makes sure to clean up and remove the `<PortalTarget>` when it's being destroyed.
 
@@ -85,7 +85,7 @@ Props working the same:
 
 ## Slots
 
-This component expects to receive a default scoped slot. If it's not passed, an an error will be logged
+This component expects to receive a default scoped slot. If it's not passed, an error will be logged.
 
 ### The `manual` slot
 

--- a/docs/api/portal-target.md
+++ b/docs/api/portal-target.md
@@ -284,7 +284,7 @@ Example:
 
 Emitted everytime the component re-renders because the content from the `<Portal>` changed.
 
-It receives two arguments, each is a `Boolean`, indicating the absense or presence of content for the target.
+It receives two arguments, each is a `Boolean`, indicating the absence or presence of content for the target.
 
 <!-- prettier-ignore -->
 ```html {4}

--- a/docs/api/wormhole.md
+++ b/docs/api/wormhole.md
@@ -24,12 +24,12 @@ The `open` method accepts one argument, an object with the following properties:
 
 `Wormhole.open({to, from, passengers})`
 
-| Property   | Required | Default  | Explanation                                                         |
-| ---------- | -------- | -------- | ------------------------------------------------------------------- |
-| to         | yes      |          | The name of the `<PortalTarget>` to send to                         |
-| from       | yes      |          | The name of the `<Portal>` this content comes from.                 |
-| passengers | yes      |          | An array of vNodes - the content to be sent to the `<PortalTarget>` |
-| order      | no       | Infinity | a number indicating the order when multipe sources for a target are used |
+| Property   | Required | Default  | Explanation                                                               |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------- |
+| to         | yes      |          | The name of the `<PortalTarget>` to send to                               |
+| from       | yes      |          | The name of the `<Portal>` this content comes from.                       |
+| passengers | yes      |          | An array of vNodes - the content to be sent to the `<PortalTarget>`       |
+| order      | no       | Infinity | a number indicating the order when multiple sources for a target are used |
 
 Even if you use this method programmatically and there is not source `<Portal>`, you still have to provide `from` - every content sent through the wormhole needs a source.
 
@@ -60,7 +60,7 @@ This is the programmatic equivalent of the following:
 ```
 
 ::: tip Server-Side Rendering
-For the reasons layed out in [the section about SSR](../guide/SSR.md), this method won't do anything during Server-Side Rendering. Portal'ing of the content will only happen on the client.
+For the reasons laid out in [the section about SSR](../guide/SSR.md), this method won't do anything during Server-Side Rendering. Portal'ing of the content will only happen on the client.
 Make sure to Read the linked section for more information.
 :::
 
@@ -125,7 +125,7 @@ Wormhole.hasSource('origin')
 ```
 
 ::: tip Server-Side Rendering
-For the reasons layed out in [the section about SSR](../guide/SSR.md), this method will aleways return `false` during Server-Side Rendering.
+For the reasons laid out in [the section about SSR](../guide/SSR.md), this method will aleways return `false` during Server-Side Rendering.
 Make sure to Read the linked section for more information.
 :::
 
@@ -143,7 +143,7 @@ Wormhole.hasTarget('destination')
 ```
 
 ::: tip Server-Side Rendering
-For the reasons layed out in [the section about SSR](../guide/SSR.md), this method will aleways return `false` during Server-Side Rendering.
+For the reasons laid out in [the section about SSR](../guide/SSR.md), this method will aleways return `false` during Server-Side Rendering.
 Make sure to Read the linked section for more information.
 :::
 
@@ -161,6 +161,6 @@ Wormhole.hasContentFor('destination')
 ```
 
 ::: tip Server-Side Rendering
-For the reasons layed out in [the section about SSR](../guide/SSR.md), this method will aleways return `false` during Server-Side Rendering.
+For the reasons laid out in [the section about SSR](../guide/SSR.md), this method will always return `false` during Server-Side Rendering.
 Make sure to Read the linked section for more information.
 :::

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -21,7 +21,7 @@ This is the starter example from the "Getting Started" page, demonstrating the b
 
 ## Dynamic sidebar content
 
-By selectively rendering different `<Portal>` components that all send to the same `<PortalTarget>` (but not at the same time), we can replace the `<PortalTarget>`'s content on demand, e.g. to put something into a sidebar area from teh main component:
+By selectively rendering different `<Portal>` components that all send to the same `<PortalTarget>` (but not at the same time), we can replace the `<PortalTarget>`'s content on demand, e.g. to put something into a sidebar area from the main component:
 
 ::: warning Missing
 The example is still missing, haven't gotten around to migrating it from [this codepen of v1](https://codepen.io/LinusBorg/pen/xdQZqa)

--- a/docs/guide/SSR.md
+++ b/docs/guide/SSR.md
@@ -9,13 +9,13 @@ When using [Vue's SSR capabilities](https://ssr.vuejs.org), portal-vue can't wor
 
 ### Disabling the portal on the server
 
-For the aforementioned reasons, starting with <Badge text="2.1.2" />, content won't be cached in the Wormhole anymore when on the server. Consequently, the HTML rendered by the server won't contain any DOM nodes in place of any `<portal-target>`
+For the aforementioned reasons, starting with <Badge text="2.1.2" />, content won't be cached in the Wormhole anymore when on the server. Consequently, the HTML rendered by the server won't contain any DOM nodes in place of any `<portal-target>`.
 
 ### Handling on the client
 
 We want to display the `<portal-target>` content on the client, though. In order to prevent any hydration mismatches, we can use a _really_ tiny [component called `<no-ssr>`](https://github.com/egoist/vue-no-ssr), written by [@egoist](https://github.com/egoist), which can solve this problem.
 
-We wrap oour `<portal-target>` elements in it, and it will prevent rendering on the server as well as on the client during hydration, preventing the error described above. Immediatly _after_ hyration, it will render the previously "hidden" content, so that the `<portal-target>` will render its content. Usually the user can hardly notice this as the update is near-immediate.
+We wrap oour `<portal-target>` elements in it, and it will prevent rendering on the server as well as on the client during hydration, preventing the error described above. Immediately _after_ hyration, it will render the previously "hidden" content, so that the `<portal-target>` will render its content. Usually the user can hardly notice this as the update is near-immediate.
 
 Example:
 

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -44,7 +44,7 @@ This can be useful if `<portal-target>`s wrapper element is creating problem for
 <portal-target name="destination" slim />
 ```
 
-The `slim` property also works on `<portal>` components when the are `disabled` (see [here](../api/portal.md#slim)).
+The `slim` property also works on `<portal>` components when they are `disabled` (see [here](../api/portal.md#slim)).
 
 ## Scoped Slots <Badge text="1.3.0+" />
 
@@ -143,11 +143,11 @@ It then provides the (auto-generated) name of the generated Target to its childr
 When `<MountingPortal>` is destroyed, it takes care of destroying the `<PortalTarget>`.
 
 :::tip
-When the `append` prop is set, the Target will be mounted to as a child of the specified element instead of replacing it.
+When the `append` prop is set, the Target is mounted as a child of the specified element instead of replacing it.
 
 This is great if you want to mount more than one PortalTarget there, for example.
 
-When `append` is used, `<MountingPortal>` will also remove the appended element when destroying the `<PortalTarget>`
+When `<PortalTarget>` is destroyed, and `append` is set, `<MountingPortal>` also removes the appended element.
 :::
 
 ### `targetEl` - The Old Way <Badge type="warning" text="1.* only"/>
@@ -158,7 +158,7 @@ When `append` is used, `<MountingPortal>` will also remove the appended element 
   <div id="app">
     <portal name="" target-el="#widget">
       <p>
-        PortalVue will dynamically mount an  instance of <portal-target>
+        PortalVue will dynamically mount an instance of <portal-target>
         in place of the Element with `id="widget"`,
         and this paragraph will be rendered inside of it.
       </p>
@@ -170,5 +170,5 @@ When `append` is used, `<MountingPortal>` will also remove the appended element 
 :::warning
 This feature had a couple of problems that were the trigger to revamp it for 2.0 as can be seen above.
 
-It was both a bit buggy and made the code harder to maintain, so we extracted it into a separate component for 2.0
+It was both a bit buggy and made the code harder to maintain, so we extracted it into a separate component for 2.0.
 :::

--- a/docs/guide/caveats.md
+++ b/docs/guide/caveats.md
@@ -10,7 +10,7 @@ Admittedly, portal-vue does a little bit of trickery to do what it does. With th
 
 ## Local state lost when toggling `disabled`
 
-When togling the `<portal>` component's `disabled` state, components in the portal slot are destroyed and re-created, which means any changes to their local state are lost.
+When toggling the `<portal>` component's `disabled` state, components in the portal slot are destroyed and re-created, which means any changes to their local state are lost.
 
 if you need to persist state, use some sort of [state management](https://portal-vue-next-preview.netlify.com/)
 
@@ -20,7 +20,7 @@ Due to the way that Vue resolves provides from parent components, it would look 
 
 ## `$parent`
 
-For the same reason, `this.$parent` will not give your the parent of the `<Portal>`, it will give your the `<PortalTarget>`, so code relying on `$parent` might break
+For the same reason, `this.$parent` will not give you the parent of the `<Portal>`, it will give you the `<PortalTarget>`, so code relying on `$parent` might break.
 
 ## `$refs`
 
@@ -34,4 +34,4 @@ this.$nextTick().then(
 )
 ```
 
-the reason is that depending on the secnario, it _can_ take one tick for the content to be sent to the [Wormhole](../api/wormhole.md) (the middleman between `<Portal>` and `<PortalTarget>`), and another one to be picked up by the `<PortalTarget>`.
+the reason is that depending on the scenario, it _can_ take one tick for the content to be sent to the [Wormhole](../api/wormhole.md) (the middleman between `<Portal>` and `<PortalTarget>`), and another one to be picked up by the `<PortalTarget>`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -79,7 +79,7 @@ Also, the code of the Examples uses the Single-File-Component Format ("`.vue`" f
   <p>
     This slot content will be rendered right here as long as the `disabled` prop
     evaluates to `true`,<br />
-    and will be rendered at the defined destination as when it is set to `false`
+    and will be rendered at the defined destination when it is set to `false`
     (which is the default).
   </p>
 </portal>
@@ -97,12 +97,12 @@ Also, the code of the Examples uses the Single-File-Component Format ("`.vue`" f
 <portal to="destination" v-if="usePortal">
   <ul>
     <li>
-      When 'usePortal' evaluates to 'true', the portal's slot content will be
+      When 'usePortal' evaluates to 'true', the portal's slot content is
       rendered at the destination.
     </li>
     <li>
-      When it evaluates to 'false', the content will be removed from the
-      destination
+      When it evaluates to 'false', the content is removed from the
+      destination.
     </li>
   </ul>
 </portal>

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -26,9 +26,9 @@ You can also check for this programmatically with [`Wormhole.hasSource() / .hasT
 
 ### MountingPortal
 
-The new `<MountingPortal>` component is a wrapper around the normal `<Portal>`. It's job is to mount a `<PortalTarget>` for the `<Portal>` to send its content to.
+The new `<MountingPortal>` component is a wrapper around the normal `<Portal>`. Its job is to mount a `<PortalTarget>` for the `<Portal>` to send its content to.
 
-This job was previously solved through the `targetEl` prop on the `<Portal>` itself, but the functionality was insuffient and broke more easily.
+This job was previously solved through the `targetEl` prop on the `<Portal>` itself, but the functionality was insufficient and broke more easily.
 
 [See API Docs for MountingPortal](../api/mounting-portal.md)
 


### PR DESCRIPTION
Not much, but I've been through the docs and saw a couple of very minor spelling issues. 
