### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add portal-vue
 ```
 
 ```javascript
-import PortalVue from 'portal-vue'
+import PortalVue from 'vue-portal'
 Vue.use(PortalVue)
 ```
 


### PR DESCRIPTION
package manager installs the lib under `vue-portal` - so that's where it should be imported from.

```
$ yarn --version

> 1.19.2
```