### PR TITLE
fix(docs): fix 'weither' typo

### DIFF
--- a/docs/api/wormhole.md
+++ b/docs/api/wormhole.md
@@ -8,7 +8,7 @@ next: false
 
 The Wormhole is not a component, it's an object that connects the `<Portal>`s to their `<PortalTarget>`s.
 
-Usually, you will never need to use this object, but you _can_ use this object to programmatically send content to a `<PortalTarget>`, check weither a target exists, and other stuff.
+Usually, you will never need to use this object, but you _can_ use this object to programmatically send content to a `<PortalTarget>`, check whether a target exists, and other stuff.
 
 :::warning Public API
 The wormhole object exposes quite a few properties and methods. With regard to semver, only the properties and methods documented below are considered part of the public API.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -47,7 +47,7 @@ More info:
 
 Previously, this event emitted the actual old and new content of the portal, which means: arrays containing vnodes.
 
-There never was a real usacase for this, so we now only emit `true` or `false` depending on wether the component has content or not, which allowed us to drop a nice little bit of code.
+There never was a real usacase for this, so we now only emit `true` or `false` depending on whether the component has content or not, which allowed us to drop a nice little bit of code.
 
 ## Things we removed
 


### PR DESCRIPTION
Fix documentation typo