### PR TITLE
simplify code contributions with the online automated one-click setup.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-full:latest
+
+RUN bash -c ". .nvm/nvm.sh \
+    && nvm install 8 \
+    && nvm use 8 \
+    && nvm alias default 8"
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: yarn install

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Add `portal-vue/nuxt` to modules section of `nuxt.config.js`
   modules: ['portal-vue/nuxt']
 }
 ```
+
+### Online One-click setup
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


### PR DESCRIPTION
Hello. I work for Gitpod.io (An Online IDE which is free for Open Source) and we are currently on a mission to simplify code contributions for popular open-source projects. 

In this Pr, I have added Gitpod config via which anyone would be able to start a workspace where Gitpod will automatically:

- clone the `portal-vue` repo.
- install all of the dependencies via `yarn install`.

This will allow newcomers to start contributing in just a single click with worrying about dependecies and setting things up.

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95806034-325cf700-0d20-11eb-9bc4-dd208c95e3c6.png)

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/portal-vue/


