### PR TITLE
Fix typo in caveats.md

### DIFF
--- a/docs/guide/caveats.md
+++ b/docs/guide/caveats.md
@@ -41,4 +41,4 @@ this.$nextTick().then(
 )
 ```
 
-The reason is that depending on the secnario, it _can_ take one tick for the content to be sent to the [Wormhole](../api/wormhole.md) (the middleman between `Portal` and `PortalTarget`), and another one to be picked up by the `PortalTarget`.
+The reason is that depending on the scenario, it _can_ take one tick for the content to be sent to the [Wormhole](../api/wormhole.md) (the middleman between `Portal` and `PortalTarget`), and another one to be picked up by the `PortalTarget`.


### PR DESCRIPTION
Fix typo: from *secnario* to *scenario*