### PR TITLE
fix: add compat config

### DIFF
--- a/src/components/portal-target.ts
+++ b/src/components/portal-target.ts
@@ -13,6 +13,7 @@ const PortalTargetContent: FunctionalComponent = (_, { slots }) => {
 }
 
 export default defineComponent({
+  compatConfig: { MODE: 3 },
   name: 'portalTarget',
   props: {
     multiple: { type: Boolean, default: false },

--- a/src/components/portal.ts
+++ b/src/components/portal.ts
@@ -65,6 +65,7 @@ export function usePortal(props: PortalProps, slots: Slots) {
 }
 
 export default defineComponent({
+  compatConfig: { MODE: 3 },
   name: 'portal',
   props: {
     disabled: { type: Boolean },


### PR DESCRIPTION
I noticed that there are some issues while using the next version of this library in combination with `@vue/compat`. I think the runtime assumed that the library needs `vue@2` behaviour but in fact it needs `vue@3`.

By the way, using the old version of this library still worked but it caused too many warnings...