### PR TITLE
Fix using uppercase in element name

### DIFF
--- a/src/components/portal.tsx
+++ b/src/components/portal.tsx
@@ -13,7 +13,7 @@ export default Vue.extend({
     order: { type: Number, default: 0 },
     slim: { type: Boolean },
     slotProps: { type: Object, default: () => ({}) },
-    tag: { type: String, default: 'DIV' },
+    tag: { type: String, default: 'div' },
     to: {
       type: String,
       default: () => String(Math.round(Math.random() * 10000000)),


### PR DESCRIPTION
This PR makes the default name for the portal element lowercase. Some linters don't like it when you use uppercase characters for this and, given browsers turn element and attribute names to lowercase when rendering the page, it's somewhat hard to know where the issue/warning comes from.

More info:
- https://html-validate.org/rules/element-case.html

Let me know if you'd like me to make any changes to this PR before mergin it in 👍 